### PR TITLE
Support GitHub Actions grouping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
         run: poetry run python -m vtr pre-commit --color=always --show-diff-on-failure
 
       - name: Run Tests
-        run: poetry run python -m vtr tests
+        run: poetry run python -m vtr tests --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Install Poetry/vscode-task-runner
+      - name: Install Poetry
         uses: threeal/pipx-install-action@v1.0.0
         with:
           packages: |
@@ -44,7 +44,7 @@ jobs:
         run: poetry install --sync
 
       - name: Run Pre-Commit Checks
-        run: python -m vtr pre-commit --color=always --show-diff-on-failure
+        run: poetry run python -m vtr pre-commit --color=always --show-diff-on-failure
 
       - name: Run Tests
-        run: python -m vtr tests
+        run: poetry run python -m vtr tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
 
       # this is done, so the local version of vscode-task-runner is used,
       # not the pypi release
+      # https://github.com/NathanVaughn/reusable-actions/blob/main/.github/workflows/python-test.yml
       - name: Install Dependencies
         run: poetry install --sync
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,43 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    if: "${{ !contains(github.event.head_commit.message, 'ci skip') }}"
 
     strategy:
       fail-fast: false
       matrix:
         python_version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
 
-    uses: NathanVaughn/reusable-actions/.github/workflows/python-test.yml@main
-    with:
-      python_version: ${{ matrix.python_version }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Poetry/vscode-task-runner
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: |
+            poetry
+
+      - name: Setup Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+          cache: poetry
+
+      - name: Cache Pre-Commit
+        uses: NathanVaughn/actions-pre-commit-cache@main
+
+      # this is done, so the local version of vscode-task-runner is used,
+      # not the pypi release
+      - name: Install Dependencies
+        run: poetry install --sync
+
+      - name: Run Pre-Commit Checks
+        run: python -m vtr pre-commit --color=always --show-diff-on-failure
+
+      - name: Run Tests
+        run: python -m vtr tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -575,4 +575,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "1a73007ce9991025e6b6253e7a1b995983e528527841f94ef096f12162afbf6d"
+content-hash = "b220a5ec6ea7de30bc267d75df59d497ef4b5e2ef03885127d2b516c80881399"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
     name = "vscode-task-runner"
-    version = "1.2.0"
+    version = "1.2.1"
     description = "Task runner for VS Code tasks.json"
     license = "MIT"
     readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@
     pyjson5     = "^1.6.2"
     dacite      = "^1.8.1"
     questionary = "^2.0.1"
+    colorama    = "^0.4.6"
 
 [tool.poetry.group.dev.dependencies]
     pre-commit  = "^3.2.0"

--- a/vtr/executor.py
+++ b/vtr/executor.py
@@ -30,9 +30,9 @@ def execute_task(
         task.subprocess_command(extra_args), input_vars_values, default_build_task
     )
 
-    with vtr.printer.group(task.label):
+    with vtr.printer.group(f"Task {task.label}"):
         vtr.printer.info(
-            f'[{index}/{total}] Executing task "{task.label}": {vtr.helpers.combine_string(cmd)}'
+            f"[{index}/{total}] Executing task {vtr.printer.yellow(task.label)}: {vtr.printer.blue(vtr.helpers.combine_string(cmd))}"
         )
         proc = subprocess.run(
             cmd,
@@ -45,7 +45,7 @@ def execute_task(
 
         if proc.returncode != 0:
             vtr.printer.error(
-                f'Task "{task.label}" returned with exit code {proc.returncode}'
+                f"Task {vtr.printer.yellow(task.label)} returned with exit code {proc.returncode}"
             )
             sys.exit(proc.returncode)
 

--- a/vtr/executor.py
+++ b/vtr/executor.py
@@ -3,6 +3,7 @@ import sys
 from typing import Dict, List, Optional
 
 import vtr.helpers
+import vtr.printer
 import vtr.variables
 from vtr.task import Task
 
@@ -20,7 +21,7 @@ def execute_task(
     for printing.
     """
     if task.is_virtual:
-        vtr.helpers.print2(
+        vtr.printer.info(
             f'[{index}/{total}] Task "{task.label}" has no direct command to execute'
         )
         return
@@ -29,16 +30,24 @@ def execute_task(
         task.subprocess_command(extra_args), input_vars_values, default_build_task
     )
 
-    vtr.helpers.print2(
-        f'[{index}/{total}] Executing task "{task.label}": {vtr.helpers.combine_string(cmd)}'
-    )
-    proc = subprocess.run(cmd, shell=False, cwd=task.cwd, env=task.env)
-
-    if proc.returncode != 0:
-        vtr.helpers.print2(
-            f'Task "{task.label}" returned with exit code {proc.returncode}'
+    with vtr.printer.group(task.label):
+        vtr.printer.info(
+            f'[{index}/{total}] Executing task "{task.label}": {vtr.helpers.combine_string(cmd)}'
         )
-        sys.exit(proc.returncode)
+        proc = subprocess.run(
+            cmd,
+            shell=False,
+            cwd=task.cwd,
+            env=task.env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+
+        if proc.returncode != 0:
+            vtr.printer.error(
+                f'Task "{task.label}" returned with exit code {proc.returncode}'
+            )
+            sys.exit(proc.returncode)
 
 
 def collect_task(task: Task, all_tasks: Optional[List[Task]] = None) -> List[Task]:

--- a/vtr/helpers.py
+++ b/vtr/helpers.py
@@ -131,10 +131,3 @@ def load_command_string(data: Union[dict, str, List[str]]) -> CommandString:
         )
     else:
         raise InvalidValue("Invalid command string data type")
-
-
-def print2(msg: str) -> None:
-    """
-    Print, but with flush set for CI/CD
-    """
-    print(msg, flush=True)

--- a/vtr/printer.py
+++ b/vtr/printer.py
@@ -1,10 +1,11 @@
 import os
 from contextlib import contextmanager
+from typing import Generator
 
 IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
-def print_flush(msg: str) -> None:
+def _print_flush(msg: str) -> None:
     """
     Prints a message, but flushes the output for CI/CD.
     """
@@ -15,7 +16,7 @@ def info(msg: str) -> None:
     """
     Prints a standard message.
     """
-    print_flush(msg)
+    _print_flush(msg)
 
 
 def error(msg: str) -> None:
@@ -23,9 +24,9 @@ def error(msg: str) -> None:
     Prints an error to the console.
     """
     if IS_GITHUB_ACTIONS:
-        print_flush(f"::error::{msg}")
+        _print_flush(f"::error::{msg}")
     else:
-        print_flush(msg)
+        _print_flush(msg)
 
 
 def start_group(name: str) -> None:
@@ -33,9 +34,9 @@ def start_group(name: str) -> None:
     Creates a new group in the GitHub Actions output.
     """
     if IS_GITHUB_ACTIONS:
-        print_flush(f"::group::{name}")
+        _print_flush(f"::group::{name}")
     else:
-        print_flush(f"Group: {name}")
+        _print_flush(f"Group: {name}")
 
 
 def end_group() -> None:
@@ -43,11 +44,11 @@ def end_group() -> None:
     Ends a group in the GitHub Actions output.
     """
     if IS_GITHUB_ACTIONS:
-        print_flush("::endgroup::")
+        _print_flush("::endgroup::")
 
 
 @contextmanager
-def group(name: str):
+def group(name: str) -> Generator[None, None, None]:
     """
     Context manager for creating a group in the GitHub Actions output.
     """

--- a/vtr/printer.py
+++ b/vtr/printer.py
@@ -2,6 +2,8 @@ import os
 from contextlib import contextmanager
 from typing import Generator
 
+import colorama
+
 IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
@@ -10,6 +12,14 @@ def _print_flush(msg: str) -> None:
     Prints a message, but flushes the output for CI/CD.
     """
     print(msg, flush=True)
+
+
+def _color_string(msg: str, color: str) -> str:
+    """
+    Returns a colored string. Respects existing colors.
+    """
+    msg = msg.replace(colorama.Style.RESET_ALL, colorama.Style.RESET_ALL + color)
+    return color + msg + colorama.Style.RESET_ALL
 
 
 def info(msg: str) -> None:
@@ -26,7 +36,28 @@ def error(msg: str) -> None:
     if IS_GITHUB_ACTIONS:
         _print_flush(f"::error::{msg}")
     else:
-        _print_flush(msg)
+        _print_flush(f"{red(msg)}")
+
+
+def blue(msg: str) -> str:
+    """
+    Returns a blue-colored string. Respects existing colors.
+    """
+    return _color_string(msg, colorama.Fore.BLUE)
+
+
+def yellow(msg: str) -> str:
+    """
+    Returns a yellow-colored string. Respects existing colors.
+    """
+    return _color_string(msg, colorama.Fore.YELLOW)
+
+
+def red(msg: str) -> str:
+    """
+    Returns a red-colored string. Respects existing colors.
+    """
+    return _color_string(msg, colorama.Fore.RED)
 
 
 def start_group(name: str) -> None:
@@ -35,8 +66,6 @@ def start_group(name: str) -> None:
     """
     if IS_GITHUB_ACTIONS:
         _print_flush(f"::group::{name}")
-    else:
-        _print_flush(f"Group: {name}")
 
 
 def end_group() -> None:
@@ -51,6 +80,7 @@ def end_group() -> None:
 def group(name: str) -> Generator[None, None, None]:
     """
     Context manager for creating a group in the GitHub Actions output.
+    Does nothing outside GitHub Actions.
     """
     start_group(name)
     try:

--- a/vtr/printer.py
+++ b/vtr/printer.py
@@ -1,0 +1,58 @@
+import os
+from contextlib import contextmanager
+
+IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+
+def print_flush(msg: str) -> None:
+    """
+    Prints a message, but flushes the output for CI/CD.
+    """
+    print(msg, flush=True)
+
+
+def info(msg: str) -> None:
+    """
+    Prints a standard message.
+    """
+    print_flush(msg)
+
+
+def error(msg: str) -> None:
+    """
+    Prints an error to the console.
+    """
+    if IS_GITHUB_ACTIONS:
+        print_flush(f"::error::{msg}")
+    else:
+        print_flush(msg)
+
+
+def start_group(name: str) -> None:
+    """
+    Creates a new group in the GitHub Actions output.
+    """
+    if IS_GITHUB_ACTIONS:
+        print_flush(f"::group::{name}")
+    else:
+        print_flush(f"Group: {name}")
+
+
+def end_group() -> None:
+    """
+    Ends a group in the GitHub Actions output.
+    """
+    if IS_GITHUB_ACTIONS:
+        print_flush("::endgroup::")
+
+
+@contextmanager
+def group(name: str):
+    """
+    Context manager for creating a group in the GitHub Actions output.
+    """
+    start_group(name)
+    try:
+        yield
+    finally:
+        end_group()


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the logging system by introducing a new 'vtr.printer' module that supports GitHub Actions grouping and improves message handling. It replaces the old print function with new methods for standard and error messages, and adds a context manager for grouping log messages.

* **New Features**:
    - Introduced a new 'vtr.printer' module to handle printing messages with support for GitHub Actions grouping.
* **Enhancements**:
    - Replaced 'vtr.helpers.print2' with 'vtr.printer.info' and 'vtr.printer.error' for better message handling and error reporting.
    - Added context manager 'vtr.printer.group' to group related log messages in GitHub Actions output.
* **Chores**:
    - Removed the 'vtr.helpers.print2' function as it is now obsolete.

<!-- Generated by sourcery-ai[bot]: end summary -->