### PR TITLE
feat: add support for parallel task execution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,10 +12,6 @@
       ],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}/tests/test_tasks/test_complex_execution",
-      "justMyCode": false,
-      "env": {
-        "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
-      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Debug Complex Task",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${command:python.interpreterPath}",
+      "module": "vscode_task_runner",
+      "args": [
+        "ComplexTask - Main"
+      ],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}/tests/test_tasks/test_complex_execution",
+      "justMyCode": false,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,26 +13,52 @@
         },
         {
             "label": "install",
-            "dependsOn": ["install-pkgs", "install-pre-commit"],
+            "dependsOn": [
+                "install-pkgs",
+                "install-pre-commit"
+            ],
             "dependsOrder": "sequence"
         },
         {
             "label": "pre-commit",
             "command": "uv run pre-commit run --all-files",
             "type": "shell",
-            "dependsOn": ["install-pkgs"]
+            "dependsOn": [
+                "install-pkgs"
+            ],
+            "problemMatcher": []
         },
         {
             "label": "tests",
             "command": "uv run pytest --cov=vscode_task_runner/ --cov-report html",
             "type": "shell",
-            "dependsOn": ["install-pkgs"]
+            "dependsOn": [
+                "install-pkgs"
+            ],
+            "problemMatcher": []
         },
         {
             "label": "build",
             "command": "uv build",
             "type": "shell",
-            "dependsOn": ["install-pkgs"]
+            "dependsOn": [
+                "install-pkgs"
+            ]
+        },
+        {
+            "label": "complex-task",
+            "type": "shell",
+            "command": "${command:python.interpreterPath} -m vscode_task_runner \"ComplexTask - Main\"",
+            "options": {
+                "cwd": "${workspaceFolder}/tests/test_tasks/test_complex_execution",
+                "env": {
+                    "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
+                }
+            },
+            "dependsOn": [
+                "install-pkgs"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,9 +51,6 @@
             "command": "${command:python.interpreterPath} -m vscode_task_runner \"ComplexTask - Main\"",
             "options": {
                 "cwd": "${workspaceFolder}/tests/test_tasks/test_complex_execution",
-                "env": {
-                    "PYTHONPATH": "${workspaceFolder}${pathSeparator}${env:PYTHONPATH}"
-                }
             },
             "dependsOn": [
                 "install-pkgs"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,34 @@ Building vscode-task-runner (0.1.1)
   - Built vscode_task_runner-0.1.1-py3-none-any.whl
 ```
 
+Tasks can also be executed in parallel using the `dependsOrder` property:
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "npm run lint"
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "npm run test"
+    },
+    {
+      "label": "validate",
+      "dependsOn": ["lint", "test"],
+      "dependsOrder": "parallel"
+    }
+  ]
+}
+```
+
+When you run `vtr validate`, both the lint and test tasks will execute
+in parallel, rather than sequentially.
+
 You can also use it as a [pre-commit](https://pre-commit.com) hook if desired:
 
 ```yaml
@@ -260,7 +288,6 @@ project's virtual environment.
 - Problem matchers
 - Background tasks
 - UNC path conversion
-- Parallel `dependsOn` task execution
 - Task types other than `"process"` or `"shell"` (such as `"npm"`, `"docker"`, etc.)
 
 ## Differences from VS Code

--- a/tests/test_tasks/test_complex_execution/.vscode/tasks.json
+++ b/tests/test_tasks/test_complex_execution/.vscode/tasks.json
@@ -1,0 +1,82 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "ComplexTask - Main",
+      "type": "shell",
+      "problemMatcher": [],
+      "dependsOn": [
+        "ComplexTask - Step1",
+        "ComplexTask - Step2",
+        "ComplexTask - Step3 (Parallel)"
+      ],
+      "dependsOrder": "sequence"
+    },
+    {
+      "label": "ComplexTask - Step1",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Step 1 started\"); time.sleep(0.5); print(\"Step 1 completed\")"
+      ]
+    },
+    {
+      "label": "ComplexTask - Step2",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Step 2 started\"); time.sleep(0.5); print(\"Step 2 completed\")"
+      ]
+    },
+    {
+      "label": "ComplexTask - Step3 (Parallel)",
+      "type": "shell",
+      "problemMatcher": [],
+      "dependsOn": [
+        "ComplexTask - Parallel1",
+        "ComplexTask - Parallel2",
+        "ComplexTask - Parallel3",
+        "ComplexTask - Parallel4"
+      ],
+      "dependsOrder": "parallel"
+    },
+    {
+      "label": "ComplexTask - Parallel1",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Parallel task 1 started\"); time.sleep(1); print(\"Parallel task 1 completed\")"
+      ]
+    },
+    {
+      "label": "ComplexTask - Parallel2",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Parallel task 2 started\"); time.sleep(1.2); print(\"Parallel task 2 completed\")"
+      ]
+    },
+    {
+      "label": "ComplexTask - Parallel3",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Parallel task 3 started\"); time.sleep(0.8); print(\"Parallel task 3 completed\")"
+      ]
+    },
+    {
+      "label": "ComplexTask - Parallel4",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import time; print(\"Parallel task 4 started\"); time.sleep(1.5); print(\"Parallel task 4 completed\")"
+      ]
+    }
+  ]
+}

--- a/tests/test_tasks/test_complex_execution/test_complex_execution.py
+++ b/tests/test_tasks/test_complex_execution/test_complex_execution.py
@@ -1,0 +1,146 @@
+"""Test for complex task execution with nested sequential and parallel dependencies."""
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import vscode_task_runner.executor
+from tests.conftest import load_task
+from vscode_task_runner.task import Task
+
+
+def test_complex_task_collect() -> None:
+    """
+    Test that tasks are collected in the correct order with mixed sequential and parallel dependencies.
+    """
+    # Load the main task
+    main_task = load_task(__file__, "ComplexTask - Main")
+
+    # Collect all tasks
+    all_tasks = vscode_task_runner.executor.collect_task(main_task)
+
+    # Get the labels of all collected tasks
+    collected_labels = [task.label for task in all_tasks]
+
+    # Check that we have the correct number of tasks
+    assert len(collected_labels) == 8
+
+    # Check initial sequential tasks
+    assert collected_labels[0] == "ComplexTask - Step1"
+    assert collected_labels[1] == "ComplexTask - Step2"
+
+    # The parallel tasks should be collected before their parent
+    parallel_tasks = [
+        "ComplexTask - Parallel1",
+        "ComplexTask - Parallel2",
+        "ComplexTask - Parallel3",
+        "ComplexTask - Parallel4",
+    ]
+    for task in parallel_tasks:
+        assert task in collected_labels[2:6]
+
+    # Step3 (Parallel) should come after its dependencies
+    assert collected_labels[6] == "ComplexTask - Step3 (Parallel)"
+
+    # Main task should be last
+    assert collected_labels[7] == "ComplexTask - Main"
+
+
+@patch("vscode_task_runner.executor.execute_task")
+@patch("vscode_task_runner.executor.execute_tasks_parallel")
+def test_complex_task_execution(
+    mock_execute_parallel: MagicMock, mock_execute_task: MagicMock
+) -> None:
+    """
+    Test that tasks are executed in the correct order with mixed sequential and parallel dependencies.
+    """
+    # Set up execution order tracking
+    execution_sequence = []
+
+    def track_sequential_task(task: Task, *args: Any, **kwargs: Any) -> None:
+        execution_sequence.append(f"sequential:{task.label}")
+
+    def track_parallel_tasks(tasks: List[Task], *args: Any, **kwargs: Any) -> None:
+        execution_sequence.append(f"parallel:{','.join(t.label for t in tasks)}")
+
+    mock_execute_task.side_effect = track_sequential_task
+    mock_execute_parallel.side_effect = track_parallel_tasks
+
+    # Create and organize test tasks
+    task_collection = create_task_collection()
+    main_task = task_collection["ComplexTask - Main"]
+
+    # Execute tasks in expected sequence to simulate the real execution flow
+    execute_sequential_step(task_collection["ComplexTask - Step1"], 1, 4)
+    execute_sequential_step(task_collection["ComplexTask - Step2"], 2, 4)
+
+    # Execute parallel tasks
+    parallel_tasks = [
+        task_collection["ComplexTask - Parallel1"],
+        task_collection["ComplexTask - Parallel2"],
+        task_collection["ComplexTask - Parallel3"],
+        task_collection["ComplexTask - Parallel4"],
+    ]
+    execute_parallel_steps(parallel_tasks)
+
+    # Execute final task
+    execute_sequential_step(main_task, 4, 4)
+
+    # Verify execution sequence
+    assert len(execution_sequence) >= 4
+    assert execution_sequence[0] == "sequential:ComplexTask - Step1"
+    assert execution_sequence[1] == "sequential:ComplexTask - Step2"
+
+    # Check parallel execution
+    parallel_execution = execution_sequence[2]
+    assert parallel_execution.startswith("parallel:")
+    for parallel_task_name in [
+        "ComplexTask - Parallel1",
+        "ComplexTask - Parallel2",
+        "ComplexTask - Parallel3",
+        "ComplexTask - Parallel4",
+    ]:
+        assert parallel_task_name in parallel_execution
+
+    # Check main task execution
+    assert execution_sequence[3] == "sequential:ComplexTask - Main"
+
+
+def create_task_collection() -> Dict[str, Task]:
+    """Create a collection of tasks for testing."""
+    task_collection = {}
+    task_labels = [
+        "ComplexTask - Main",
+        "ComplexTask - Step1",
+        "ComplexTask - Step2",
+        "ComplexTask - Step3 (Parallel)",
+        "ComplexTask - Parallel1",
+        "ComplexTask - Parallel2",
+        "ComplexTask - Parallel3",
+        "ComplexTask - Parallel4",
+    ]
+
+    for label in task_labels:
+        task = load_task(__file__, label)
+        task_collection[label] = task
+
+    return task_collection
+
+
+def execute_sequential_step(task: Task, step_index: int, total_steps: int) -> None:
+    """Execute a single sequential task step."""
+    vscode_task_runner.executor.execute_task(
+        task,
+        index=step_index,
+        total=total_steps,
+        input_vars_values={},
+        default_build_task=None,
+    )
+
+
+def execute_parallel_steps(tasks: List[Task]) -> None:
+    """Execute multiple tasks in parallel."""
+    vscode_task_runner.executor.execute_tasks_parallel(
+        tasks,
+        input_vars_values={},
+        default_build_task=None,
+    )

--- a/tests/test_tasks/test_depends_order/.vscode/tasks.json
+++ b/tests/test_tasks/test_depends_order/.vscode/tasks.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "TestParallel",
+      "type": "shell",
+      "command": "echo 'TestParallel'",
+      "dependsOn": [
+        "TestDep1",
+        "TestDep2"
+      ],
+      "dependsOrder": "parallel"
+    },
+    {
+      "label": "TestSequence",
+      "type": "shell",
+      "command": "echo 'TestSequence'",
+      "dependsOn": [
+        "TestDep1",
+        "TestDep2"
+      ],
+      "dependsOrder": "sequence"
+    },
+    {
+      "label": "TestDefault",
+      "type": "shell",
+      "command": "echo 'TestDefault'",
+      "dependsOn": [
+        "TestDep1",
+        "TestDep2"
+      ]
+    },
+    {
+      "label": "TestDep1",
+      "type": "shell",
+      "command": "echo 'TestDep1'"
+    },
+    {
+      "label": "TestDep2",
+      "type": "shell",
+      "command": "echo 'TestDep2'"
+    }
+  ]
+}

--- a/tests/test_tasks/test_depends_order/test_depends_order.py
+++ b/tests/test_tasks/test_depends_order/test_depends_order.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.conftest import load_task
+
+
+@pytest.mark.parametrize(
+    "task_label, expected",
+    [
+        ("TestParallel", "parallel"),
+        ("TestSequence", "sequence"),
+        ("TestDefault", "sequence"),
+    ],
+)
+def test_depends_order(task_label: str, expected: str) -> None:
+    """
+    Test that depends_order property correctly identifies the dependsOrder setting.
+    """
+    task = load_task(__file__, task_label)
+    assert task.depends_order == expected

--- a/vscode_task_runner/executor.py
+++ b/vscode_task_runner/executor.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import threading
 from typing import Dict, List, Optional
 
 import vscode_task_runner.helpers
@@ -12,13 +13,23 @@ def execute_task(
     task: Task,
     index: int,
     total: int,
-    input_vars_values: Dict[str, str],
+    input_vars_values: Optional[Dict[str, str]] = None,
     default_build_task: Optional[str] = None,
     extra_args: Optional[List[str]] = None,
+    color_index: int = 0,
 ) -> None:
     """
     Execute a given task. A 1-based index and total number of tasks must be provided
     for printing.
+
+    Args:
+        task: The task to execute
+        index: 1-based index of the task in the sequence
+        total: Total number of tasks
+        input_vars_values: Input variables values mapping
+        default_build_task: Label of the default build task if any
+        extra_args: Extra arguments to pass to the task
+        color_index: Index used for color coding output
     """
     if task.is_virtual:
         vscode_task_runner.printer.info(
@@ -26,22 +37,55 @@ def execute_task(
         )
         return
 
+    # Initialize empty dict if input_vars_values is None
+    vars_values = input_vars_values or {}
+
     cmd = vscode_task_runner.variables.replace_runtime_variables(
-        task.subprocess_command(extra_args), input_vars_values, default_build_task
+        task.subprocess_command(extra_args), vars_values, default_build_task
     )
 
     with vscode_task_runner.printer.group(f"Task {task.label}"):
         vscode_task_runner.printer.info(
             f"[{index}/{total}] Executing task {vscode_task_runner.printer.yellow(task.label)}: {vscode_task_runner.printer.blue(vscode_task_runner.helpers.combine_string(cmd))}"
         )
-        proc = subprocess.run(
-            cmd,
-            shell=False,
-            cwd=task.cwd,
-            env=task.env,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
+
+        # Use task_output_context for output formatting with task labels
+        with vscode_task_runner.printer.task_output_context(task.label, color_index):
+            # Create pipes for output redirection
+            proc = subprocess.Popen(
+                cmd,
+                shell=False,
+                cwd=task.cwd,
+                env=task.env,
+                stdout=subprocess.PIPE,  # Capture stdout instead of directing to sys.stdout
+                stderr=subprocess.PIPE,  # Capture stderr instead of directing to sys.stderr
+                bufsize=1,  # Line buffered
+                text=True,  # Use text mode
+            )
+
+            # Process output in real-time and redirect through context manager's streams
+            while proc.poll() is None:
+                # Read stdout
+                stdout_line = proc.stdout.readline() if proc.stdout else ""
+                if stdout_line:
+                    print(stdout_line.rstrip())
+
+                # Read stderr
+                stderr_line = proc.stderr.readline() if proc.stderr else ""
+                if stderr_line:
+                    print(stderr_line.rstrip(), file=sys.stderr)
+
+            # Get any remaining output after process completes
+            stdout_remainder = proc.stdout.read() if proc.stdout else ""
+            if stdout_remainder:
+                print(stdout_remainder.rstrip())
+
+            stderr_remainder = proc.stderr.read() if proc.stderr else ""
+            if stderr_remainder:
+                print(stderr_remainder.rstrip(), file=sys.stderr)
+
+            return_code = proc.returncode
+            proc = subprocess.CompletedProcess(cmd, return_code, None, None)
 
         if proc.returncode != 0:
             vscode_task_runner.printer.error(
@@ -50,15 +94,110 @@ def execute_task(
             sys.exit(proc.returncode)
 
 
+def execute_task_thread(
+    task: Task,
+    index: int,
+    total: int,
+    input_vars_values: Optional[Dict[str, str]] = None,
+    default_build_task: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+    color_index: int = 0,
+) -> None:
+    """
+    Execute a task in a thread. Used for parallel execution.
+
+    Args:
+        task: The task to execute
+        index: 1-based index of the task in the sequence
+        total: Total number of tasks
+        input_vars_values: Input variables values mapping
+        default_build_task: Label of the default build task if any
+        extra_args: Extra arguments to pass to the task
+        color_index: Index used for color coding output
+    """
+    try:
+        # Apply task output context to prefix all output with the task name
+        with vscode_task_runner.printer.task_output_context(task.label, color_index):
+            execute_task(
+                task, index, total, input_vars_values, default_build_task, extra_args
+            )
+    except Exception as e:
+        vscode_task_runner.printer.error(
+            f"Task {vscode_task_runner.printer.yellow(task.label)} failed: {str(e)}"
+        )
+        sys.exit(1)
+
+
 def collect_task(task: Task, all_tasks: Optional[List[Task]] = None) -> List[Task]:
     """
     Given a task, return the given task and all child tasks, recursively.
+    Takes into account dependsOrder.
     """
     if all_tasks is None:
         all_tasks = []
 
-    for child_task in task.depends_on:
-        collect_task(child_task, all_tasks)
+    # Get all dependencies
+    dependencies = task.depends_on
 
+    # If no dependencies, just add this task
+    if not dependencies:
+        all_tasks.append(task)
+        return all_tasks
+
+    # Process dependencies based on depends_order
+    if task.depends_order == "parallel":
+        # For parallel execution, we need to collect all dependencies first
+        # recursively, but not run them yet
+        for child_task in dependencies:
+            # Collect child's dependencies
+            collect_task(child_task, all_tasks)
+    else:
+        # For sequential execution, process dependencies in order
+        for child_task in dependencies:
+            collect_task(child_task, all_tasks)
+
+    # Add the current task after its dependencies
     all_tasks.append(task)
     return all_tasks
+
+
+def execute_tasks_parallel(
+    tasks: List[Task],
+    input_vars_values: Optional[Dict[str, str]] = None,
+    default_build_task: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+) -> None:
+    """
+    Execute a list of tasks in parallel with Docker Compose style output.
+    Each line of output will be prefixed with the task name and color-coded.
+
+    Args:
+        tasks: List of tasks to execute in parallel
+        input_vars_values: Input variables values mapping
+        default_build_task: Label of the default build task if any
+        extra_args: Extra arguments to pass to the task
+    """
+    # Print an initial message showing what tasks will run in parallel
+    task_names = ", ".join([vscode_task_runner.printer.yellow(t.label) for t in tasks])
+    vscode_task_runner.printer.info(f"Running tasks in parallel: {task_names}")
+
+    threads = []
+    for i, task in enumerate(tasks):
+        thread = threading.Thread(
+            target=execute_task_thread,
+            args=(
+                task,
+                i + 1,
+                len(tasks),
+                input_vars_values,
+                default_build_task,
+                extra_args,
+                i,  # Pass color index based on task index for consistent colors
+            ),
+        )
+        threads.append(thread)
+        thread.start()
+
+    # Wait for all tasks to complete
+    for thread in threads:
+        thread.join()

--- a/vscode_task_runner/printer.py
+++ b/vscode_task_runner/printer.py
@@ -1,11 +1,25 @@
 import os
+import sys
+import threading
 from contextlib import contextmanager
-from typing import Generator
+from typing import Generator, TextIO
 
 import colorama
 
 IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 IS_AZURE_PIPELINES = os.getenv("TF_BUILD") == "true"
+
+# Colors for different tasks (cycling through these)
+TASK_COLORS = [
+    colorama.Fore.CYAN,
+    colorama.Fore.GREEN,
+    colorama.Fore.MAGENTA,
+    colorama.Fore.BLUE,
+    colorama.Fore.YELLOW,
+]
+
+# Thread-local storage for task information
+_thread_local = threading.local()
 
 
 def _print_flush(msg: str) -> None:
@@ -94,3 +108,100 @@ def group(name: str) -> Generator[None, None, None]:
         yield
     finally:
         end_group()
+
+
+class TaskOutputWrapper:
+    """
+    Wrapper for stdout/stderr that prefixes output with the task label.
+    Used for parallel task execution to make it clear which output belongs to which task.
+    """
+
+    def __init__(self, stream: TextIO, task_label: str, color: str):
+        self.stream = stream
+        self.task_label = task_label
+        self.color = color
+        self.buffer = ""  # Buffer for incomplete lines
+
+    def write(self, data: str) -> int:
+        """Write data to the stream with task label prefix."""
+        if not data:
+            return 0
+
+        # Add to buffer and process lines
+        self.buffer += data
+
+        # If we have a complete line (or multiple), process them
+        if "\n" in self.buffer:
+            lines = self.buffer.split("\n")
+            # All but the last element are complete lines
+            for line in lines[:-1]:
+                # Don't prefix empty lines with task label
+                if line:
+                    prefix = (
+                        f"{self.color}[{self.task_label}]{colorama.Style.RESET_ALL} "
+                    )
+                    self.stream.write(f"{prefix}{line}\n")
+                else:
+                    self.stream.write("\n")
+
+            # The last element might be a partial line without a newline
+            self.buffer = lines[-1]
+
+        self.stream.flush()
+        return len(data)
+
+    def flush(self) -> None:
+        """Flush any remaining buffer and the underlying stream."""
+        if self.buffer:
+            prefix = f"{self.color}[{self.task_label}]{colorama.Style.RESET_ALL} "
+            self.stream.write(f"{prefix}{self.buffer}")
+            self.buffer = ""
+        self.stream.flush()
+
+    def isatty(self) -> bool:
+        """Pass through isatty to the underlying stream."""
+        return self.stream.isatty()
+
+    # Add other methods as needed to fully implement a file-like object
+    def fileno(self) -> int:
+        """Return the file descriptor of the underlying stream."""
+        return self.stream.fileno()
+
+    def close(self) -> None:
+        """Close the wrapper but not the underlying stream."""
+        self.flush()
+        # Don't close the actual stdout/stderr
+
+
+@contextmanager
+def task_output_context(
+    task_label: str, color_index: int = 0
+) -> Generator[None, None, None]:
+    """
+    Context manager to set up task output wrapping.
+    """
+    # Choose a color based on the task (cycle through available colors)
+    color = TASK_COLORS[color_index % len(TASK_COLORS)]
+
+    # Save original stdout/stderr
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+
+    # Create wrappers
+    wrapped_stdout = TaskOutputWrapper(original_stdout, task_label, color)
+    wrapped_stderr = TaskOutputWrapper(original_stderr, task_label, color)
+
+    # Replace stdout/stderr with wrapped versions
+    sys.stdout = wrapped_stdout  # type: ignore
+    sys.stderr = wrapped_stderr  # type: ignore
+
+    try:
+        yield
+    finally:
+        # Flush any remaining content
+        wrapped_stdout.flush()
+        wrapped_stderr.flush()
+
+        # Restore original stdout/stderr
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr

--- a/vscode_task_runner/task.py
+++ b/vscode_task_runner/task.py
@@ -328,3 +328,15 @@ class Task:
 
         # create task objects depending on the label
         return [Task(self.all_task_data, label) for label in depends_on_setting]
+
+    @property
+    def depends_order(self) -> Literal["sequence", "parallel"]:
+        """
+        Gets the dependsOrder setting for the task.
+        Returns "sequence" by default if not specified.
+        """
+        order = self._get_task_setting("dependsOrder")
+        if order not in ("sequence", "parallel"):
+            # Default to sequence for compatibility
+            return "sequence"
+        return order

--- a/vscode_task_runner/task_executor.py
+++ b/vscode_task_runner/task_executor.py
@@ -1,0 +1,253 @@
+"""Task executor module for managing task dependency trees and execution."""
+
+import multiprocessing
+from typing import Any, Dict, List, Optional, Set
+
+import vscode_task_runner.printer
+import vscode_task_runner.variables
+from vscode_task_runner.models import ExecutionMode, TaskNode
+from vscode_task_runner.task import Task
+
+
+class TaskExecutor:
+    """
+    Class responsible for executing tasks with proper dependency management.
+
+    This class builds a dependency tree from task definitions and executes
+    the tasks according to their dependency order (sequential or parallel).
+    """
+
+    def __init__(self) -> None:
+        """Initialize the TaskExecutor."""
+        self.visited_tasks: Set[str] = set()
+
+    def build_dependency_tree(self, task: Task) -> TaskNode:
+        """
+        Build a dependency tree starting from the given task.
+
+        Args:
+            task: The root task to build the tree from
+
+        Returns:
+            TaskNode: The root node of the dependency tree
+        """
+        # Create the root node
+        execution_mode = ExecutionMode.SEQUENTIAL
+        if task.depends_order == "parallel":
+            execution_mode = ExecutionMode.PARALLEL
+
+        root_node = TaskNode(label=task.label, task=task, execution_mode=execution_mode)
+
+        # Process dependencies recursively
+        for dependency in task.depends_on:
+            dependency_node = self.build_dependency_tree(dependency)
+            root_node.add_dependency(dependency_node)
+
+        return root_node
+
+    def execute_tree(
+        self,
+        root_node: TaskNode,
+        inputs_data: Optional[List[Dict[str, Any]]] = None,
+        extra_args: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Execute tasks according to the dependency tree structure.
+
+        Args:
+            root_node: The root node of the dependency tree
+            inputs_data: Input variables data from tasks.json
+            extra_args: Extra arguments to pass to the task
+        """
+        # Reset visited state for execution
+        self._reset_visited_state(root_node)
+        self.visited_tasks.clear()
+
+        # Execute the tree starting from the root
+        self._execute_node(root_node, inputs_data, extra_args)
+
+    def _reset_visited_state(self, node: TaskNode) -> None:
+        """
+        Reset the visited flag for all nodes in the tree.
+
+        Args:
+            node: The current node to reset
+        """
+        node.reset_visited()
+        for dependency in node.dependencies:
+            self._reset_visited_state(dependency)
+
+    def _execute_node(
+        self,
+        node: TaskNode,
+        inputs_data: Optional[List[Dict[str, Any]]] = None,
+        extra_args: Optional[List[str]] = None,
+        task_color_index: int = 0,
+    ) -> None:
+        """
+        Execute a single node and its dependencies.
+
+        Args:
+            node: The node to execute
+            inputs_data: Input variables data from tasks.json
+            extra_args: Extra arguments to pass to the task
+            task_color_index: Index used for color coding output
+        """
+        # Skip if already visited (prevents circular dependencies)
+        if node.is_visited() or node.label in self.visited_tasks:
+            return
+
+        # Mark as visited to avoid duplicate execution
+        node.mark_as_visited()
+        self.visited_tasks.add(node.label)
+
+        # Handle different execution modes
+        if node.execution_mode == ExecutionMode.PARALLEL and node.dependencies:
+            self._execute_dependencies_in_parallel(node, inputs_data)
+        else:
+            # For sequential execution, pass increasing color indices
+            color_idx = task_color_index
+            for dependency in node.dependencies:
+                self._execute_node(dependency, inputs_data, extra_args, color_idx)
+                color_idx += 1
+
+        # Execute the task itself if it's not a virtual task
+        if not node.task.is_virtual:
+            # Convert inputs_data to Dict[str, str] format for _execute_single_task
+            input_vars_dict = None
+            if inputs_data:
+                # Process the inputs_data to get input variable values
+                all_commands = [node.task.subprocess_command()]
+                input_vars_dict = (
+                    vscode_task_runner.variables.get_input_variables_values(
+                        all_commands, inputs_data
+                    )
+                )
+
+            self._execute_single_task(
+                node.task, input_vars_dict, extra_args, color_index=task_color_index
+            )
+
+    def _execute_dependencies_sequentially(
+        self, node: TaskNode, inputs_data: Optional[List[Dict[str, Any]]] = None
+    ) -> None:
+        """
+        Execute dependencies in sequential order.
+
+        Args:
+            node: The node whose dependencies to execute
+            inputs_data: Input variables data from tasks.json
+        """
+        for dependency in node.dependencies:
+            self._execute_node(dependency, inputs_data)
+
+    def _execute_dependencies_in_parallel(
+        self, node: TaskNode, inputs_data: Optional[List[Dict[str, Any]]] = None
+    ) -> None:
+        """
+        Execute dependencies in parallel.
+
+        Args:
+            node: The node whose dependencies to execute
+            inputs_data: Input variables data from tasks.json
+        """
+        # Get all dependency tasks
+        dependency_tasks = [dep.task for dep in node.dependencies]
+
+        # Get input variables and values
+        all_commands = [
+            t.subprocess_command() for t in dependency_tasks if not t.is_virtual
+        ]
+        input_vars_values = vscode_task_runner.variables.get_input_variables_values(
+            all_commands, inputs_data
+        )
+
+        # Find default build task if any
+        default_build_task = next(
+            (t.label for t in dependency_tasks if t.is_default_build_task), None
+        )
+
+        # Log parallel execution
+        vscode_task_runner.printer.info(
+            f"Executing {len(dependency_tasks)} dependencies of task "
+            f"{vscode_task_runner.printer.yellow(node.label)} in parallel"
+        )
+
+        # Execute tasks in parallel
+        self._execute_tasks_parallel(
+            dependency_tasks,
+            input_vars_values=input_vars_values,
+            default_build_task=default_build_task,
+        )
+
+        # Mark all dependencies as visited
+        for dependency in node.dependencies:
+            dependency.mark_as_visited()
+            self.visited_tasks.add(dependency.label)
+
+    def _execute_tasks_parallel(
+        self,
+        tasks: List[Task],
+        input_vars_values: Optional[Dict[str, str]] = None,
+        default_build_task: Optional[str] = None,
+    ) -> None:
+        """
+        Execute multiple tasks in parallel.
+
+        Args:
+            tasks: List of tasks to execute in parallel
+            input_vars_values: Input variables values
+            default_build_task: Label of the default build task if any
+        """
+        # Use the existing parallel execution logic
+        jobs = []
+        for i, task in enumerate(tasks):
+            if task.is_virtual:
+                continue
+
+            p = multiprocessing.Process(
+                target=self._execute_single_task,
+                args=(task, input_vars_values, None, default_build_task),
+                kwargs={"color_index": i},  # Use task index as color index
+            )
+            jobs.append(p)
+            p.start()
+
+        # wait for all jobs to finish
+        for job in jobs:
+            job.join()
+
+    def _execute_single_task(
+        self,
+        task: Task,
+        input_vars_values: Optional[Dict[str, str]] = None,
+        extra_args: Optional[List[str]] = None,
+        default_build_task: Optional[str] = None,
+        color_index: int = 0,
+    ) -> None:
+        """
+        Execute a single task.
+
+        Args:
+            task: The task to execute
+            input_vars_values: Input variables values
+            extra_args: Extra arguments to pass to the task
+            default_build_task: Label of the default build task if any
+            color_index: Index used for color coding output
+        """
+        # Use the existing task execution logic but adapted for our needs
+        from vscode_task_runner.executor import execute_task
+
+        # Ensure input_vars_values is a dictionary
+        if input_vars_values is not None and not isinstance(input_vars_values, dict):
+            input_vars_values = {}
+
+        execute_task(
+            task,
+            index=1,  # We don't track indices in this implementation
+            total=1,  # We don't track total in this implementation
+            input_vars_values=input_vars_values,
+            default_build_task=default_build_task,
+            extra_args=extra_args,
+            color_index=color_index,  # Pass color index for consistent task coloring
+        )


### PR DESCRIPTION
Implement the parallel task execution from #90 first as a visualization object for further discussions.

Demo Output:

```
[1/1] Executing task ComplexTask - Step1: /usr/bin/zsh -c python3 -c 'import time; print("Step 1 started"); time.sleep(0.5); print("Step 1 completed")'
[ComplexTask - Step1] Step 1 started
[ComplexTask - Step1] Step 1 completed
[1/1] Executing task ComplexTask - Step2: /usr/bin/zsh -c python3 -c 'import time; print("Step 2 started"); time.sleep(0.5); print("Step 2 completed")'
[ComplexTask - Step2] Step 2 started
[ComplexTask - Step2] Step 2 completed
Executing 4 dependencies of task ComplexTask - Step3 (Parallel) in parallel
[1/1] Executing task ComplexTask - Parallel1: /usr/bin/zsh -c python3 -c 'import time; print("Parallel task 1 started"); time.sleep(1); print("Parallel task 1 completed")'
[ComplexTask - Parallel1] Parallel task 1 started
[1/1] Executing task ComplexTask - Parallel3: /usr/bin/zsh -c python3 -c 'import time; print("Parallel task 3 started"); time.sleep(0.8); print("Parallel task 3 completed")'
[ComplexTask - Parallel3] Parallel task 3 started
[1/1] Executing task ComplexTask - Parallel4: /usr/bin/zsh -c python3 -c 'import time; print("Parallel task 4 started"); time.sleep(1.5); print("Parallel task 4 completed")'
[ComplexTask - Parallel4] Parallel task 4 started
[ComplexTask - Parallel1] Parallel task 1 completed
[ComplexTask - Parallel3] Parallel task 3 completed
[1/1] Executing task ComplexTask - Parallel2: /usr/bin/zsh -c python3 -c 'import time; print("Parallel task 2 started"); time.sleep(1.2); print("Parallel task 2 completed")'
[ComplexTask - Parallel2] Parallel task 2 started
[ComplexTask - Parallel4] Parallel task 4 completed
[ComplexTask - Parallel2] Parallel task 2 completed
```