### PR TITLE
Fix Devcontainer write permissions by syncing container user UID/GID with host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,11 @@
 {
     "image": "ghcr.io/nathanvaughn/devcontainers/python:latest",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "username": "automatic",
+            "updateRemoteUserUID": true
+        }
+    },
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
**Problem**
Saving files inside the Devcontainer intermittently failed with “permission denied”.
Cause: UID/GID mismatch between the host user and the container’s default user when mounting the workspace.

**Fix**
Add the `common-utils` Dev Container feature with:
- `"username": "automatic"` (detect image’s default user)
- `"updateRemoteUserUID": true` (align UID/GID to host)

This addresses the root cause without needing recurring chown steps.